### PR TITLE
Implement the optimized message cache

### DIFF
--- a/src/Attributes/LongRunningAttribute.cs
+++ b/src/Attributes/LongRunningAttribute.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using Discord;
 using Discord.Commands;
@@ -19,7 +19,9 @@ namespace Fergun.Attributes
             IUserMessage response;
             ulong messageId = 0;
             bool? found = services.GetService<CommandCacheService>()?.TryGetValue(context.Message.Id, out messageId);
-            if ((found ?? false) && (response = (IUserMessage)await context.Channel.GetMessageAsync(messageId)) != null)
+            var cache = services.GetService<MessageCacheService>();
+
+            if ((found ?? false) && (response = (IUserMessage)await context.Channel.GetMessageAsync(cache, messageId)) != null)
             {
                 await response.ModifyAsync(x =>
                 {

--- a/src/Config/FergunConfig.cs
+++ b/src/Config/FergunConfig.cs
@@ -107,7 +107,7 @@ namespace Fergun
         public bool ServerMembersIntent { get; private set; }
 
         /// <summary>
-        /// Gets the message cache size.
+        /// Gets the message cache size. If <see cref="UseMessageCacheService"/> is set to <see langword="true"/>, this property will be used in the optimized cache service instead.
         /// </summary>
         [JsonProperty]
         public int MessageCacheSize { get; private set; } = 100;
@@ -140,7 +140,7 @@ namespace Fergun
         public bool UseCommandCacheService { get; private set; } = true;
 
         /// <summary>
-        /// Gets whether the message cache service should be used.
+        /// Gets whether the optimized message cache service should be used.
         /// </summary>
         [JsonProperty]
         public bool UseMessageCacheService { get; private set; } = true;

--- a/src/Extensions/Extensions.cs
+++ b/src/Extensions/Extensions.cs
@@ -10,6 +10,7 @@ using Discord;
 using Discord.Commands;
 using Fergun.Attributes;
 using Fergun.Attributes.Preconditions;
+using Fergun.Services;
 using Fergun.Utils;
 using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json;
@@ -250,14 +251,15 @@ namespace Fergun.Extensions
         /// </summary>
         /// <param name="context">The channel to search.</param>
         /// <param name="messageCount">The number of messages to search.</param>
+        /// <param name="cache">The message cache service.</param>
         /// <param name="onlyImage">Get only urls of images.</param>
         /// <param name="url">An optional url to use before searching in the channel.</param>
         /// <param name="maxSize">The maximum file size in bytes, <see cref="Constants.AttachmentSizeLimit"/> by default.</param>
         /// <returns>A task that represents an asynchronous search operation.</returns>
-        public static Task<(string, UrlFindResult)> GetLastUrlAsync(this ICommandContext context, int messageCount, bool onlyImage = false,
-            string url = null, long maxSize = Constants.AttachmentSizeLimit)
+        public static Task<(string, UrlFindResult)> GetLastUrlAsync(this ICommandContext context, int messageCount, MessageCacheService cache = null,
+            bool onlyImage = false, string url = null, long maxSize = Constants.AttachmentSizeLimit)
         {
-            return context.Channel.GetLastUrlAsync(messageCount, onlyImage, context.Message, url, maxSize);
+            return context.Channel.GetLastUrlAsync(messageCount, cache, onlyImage, context.Message, url, maxSize);
         }
 
         public static bool IsNsfw(this ICommandContext context)

--- a/src/Extensions/MessageExtensions.cs
+++ b/src/Extensions/MessageExtensions.cs
@@ -95,7 +95,7 @@ namespace Fergun.Extensions
                 x.AllowedMentions = allowedMentions ?? Optional.Create<AllowedMentions>();
             });
 
-            return await message.Channel.GetMessageAsync(message.Id) as IUserMessage;
+            return await message.Channel.GetMessageAsync(cache, message.Id) as IUserMessage;
         }
     }
 }

--- a/src/Extensions/MessageExtensions.cs
+++ b/src/Extensions/MessageExtensions.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Discord;
 using Discord.Net;
 using Discord.WebSocket;
+using Fergun.Services;
 
 namespace Fergun.Extensions
 {
@@ -11,11 +12,13 @@ namespace Fergun.Extensions
         /// <summary>
         /// Tries to delete this message.
         /// </summary>
-        public static async Task<bool> TryDeleteAsync(this IMessage message)
+        /// <param name="message">The message.</param>
+        /// <param name="cache">The message cache service.</param>
+        public static async Task<bool> TryDeleteAsync(this IMessage message, MessageCacheService cache = null)
         {
             if (message == null) return false;
 
-            message = await message.Channel.GetMessageAsync(message.Id);
+            message = await message.Channel.GetMessageAsync(cache, message.Id);
 
             if (message == null) return false;
 
@@ -47,12 +50,12 @@ namespace Fergun.Extensions
         /// <summary>
         /// Tries to remove all reactions from this message.
         /// </summary>
-        public static async Task<bool> TryRemoveAllReactionsAsync(this IMessage message)
+        public static async Task<bool> TryRemoveAllReactionsAsync(this IMessage message, MessageCacheService cache = null)
         {
             if (message == null) return false;
 
             // get the updated message with the reactions
-            message = await message.Channel.GetMessageAsync(message.Id);
+            message = await message.Channel.GetMessageAsync(cache, message.Id);
 
             if (message == null || message.Reactions.Count == 0) return false;
 
@@ -76,9 +79,10 @@ namespace Fergun.Extensions
         /// Modifies this message or re-sends it if no longer exists.
         /// </summary>
         /// <returns>A new message or a modified one.</returns>
-        public static async Task<IUserMessage> ModifyOrResendAsync(this IUserMessage message, string content = null, Embed embed = null, AllowedMentions allowedMentions = null)
+        public static async Task<IUserMessage> ModifyOrResendAsync(this IUserMessage message, string content = null, Embed embed = null,
+            AllowedMentions allowedMentions = null, MessageCacheService cache = null)
         {
-            bool isValid = await message.Channel.GetMessageAsync(message.Id) != null;
+            bool isValid = await message.Channel.GetMessageAsync(cache, message.Id) != null;
             if (!isValid)
             {
                 return await message.Channel.SendMessageAsync(content, embed: embed, allowedMentions: allowedMentions);

--- a/src/Extensions/MessageExtensions.cs
+++ b/src/Extensions/MessageExtensions.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using System.Threading.Tasks;
 using Discord;
 using Discord.Net;
@@ -61,18 +60,11 @@ namespace Fergun.Extensions
 
             bool manageMessages = message.Author is IGuildUser guildUser && guildUser.GetPermissions((IGuildChannel)message.Channel).ManageMessages;
 
-            if (manageMessages)
-            {
-                await message.RemoveAllReactionsAsync();
-            }
-            else
-            {
-                var botReactions = message.Reactions.Where(x => x.Value.IsMe).Select(x => x.Key).ToArray();
-                if (botReactions.Length == 0) return false;
+            if (!manageMessages) return false;
 
-                await (message as IUserMessage).RemoveReactionsAsync(message.Author, botReactions);
-            }
+            await message.RemoveAllReactionsAsync();
             return true;
+
         }
 
         /// <summary>

--- a/src/FergunClient.cs
+++ b/src/FergunClient.cs
@@ -130,7 +130,7 @@ namespace Fergun
             Constants.ClientConfig.AlwaysDownloadUsers = Config.AlwaysDownloadUsers;
             await _logService.LogAsync(new LogMessage(LogSeverity.Verbose, "Bot", $"Always download users: {Constants.ClientConfig.AlwaysDownloadUsers}"));
 
-            Constants.ClientConfig.MessageCacheSize = Config.MessageCacheSize;
+            Constants.ClientConfig.MessageCacheSize = Config.UseMessageCacheService ? 0 : Config.MessageCacheSize;
             await _logService.LogAsync(new LogMessage(LogSeverity.Verbose, "Bot", $"Message cache size: {Constants.ClientConfig.MessageCacheSize}"));
 
             await _logService.LogAsync(new LogMessage(LogSeverity.Verbose, "Bot", $"Messages to search limit: {Config.MessagesToSearchLimit}"));
@@ -388,9 +388,8 @@ namespace Fergun
                     : CommandCacheService.Disabled)
                 .AddSingletonIf(Config.UseReliabilityService, new ReliabilityService(_client, message => _ = _logService.LogAsync(message)))
                 .AddSingleton(Config.UseMessageCacheService
-                    ? new MessageCacheService(_client, GuildUtils.UserConfigCache,
-                    log => _ = _logService.LogAsync(log), Constants.MessageCacheClearInterval,
-                    Constants.MaxMessageCacheLongevity)
+                    ? new MessageCacheService(_client, Config.MessageCacheSize,
+                    log => _ = _logService.LogAsync(log), Constants.MessageCacheClearInterval, Constants.MaxMessageCacheLongevity)
                     : MessageCacheService.Disabled)
                 .BuildServiceProvider();
         }

--- a/src/FergunClient.cs
+++ b/src/FergunClient.cs
@@ -132,7 +132,7 @@ namespace Fergun
             await _logService.LogAsync(new LogMessage(LogSeverity.Verbose, "Bot", $"Always download users: {Constants.ClientConfig.AlwaysDownloadUsers}"));
 
             Constants.ClientConfig.MessageCacheSize = Config.UseMessageCacheService ? 0 : Config.MessageCacheSize;
-            await _logService.LogAsync(new LogMessage(LogSeverity.Verbose, "Bot", $"Message cache size: {Constants.ClientConfig.MessageCacheSize}"));
+            await _logService.LogAsync(new LogMessage(LogSeverity.Verbose, "Bot", $"Message cache size: {Config.MessageCacheSize}"));
 
             await _logService.LogAsync(new LogMessage(LogSeverity.Verbose, "Bot", $"Messages to search limit: {Config.MessagesToSearchLimit}"));
 
@@ -175,7 +175,7 @@ namespace Fergun
 
             _logService.Dispose();
 
-            _messageCacheService = Config.UseMessageCacheService
+            _messageCacheService = Config.UseMessageCacheService && Config.MessageCacheSize > 0
                 ? new MessageCacheService(_client, Config.MessageCacheSize,
                     log => _ = _logService.LogAsync(log), Constants.MessageCacheClearInterval, Constants.MaxMessageCacheLongevity)
                 : MessageCacheService.Disabled;

--- a/src/Modules/AIDungeon.cs
+++ b/src/Modules/AIDungeon.cs
@@ -332,7 +332,17 @@ namespace Fergun.Modules
             builder.Title = "AI Dungeon";
             builder.Description = FergunClient.Config.LoadingEmote + " " + string.Format(Locate("GeneratingNewAdventure"), _modes.Keys.ElementAt(modeIndex), characters.Keys.ElementAt(characterIndex));
 
-            _ = message.TryRemoveAllReactionsAsync();
+            bool manageMessages = message.Author is IGuildUser guildUser && guildUser.GetPermissions((IGuildChannel)message.Channel).ManageMessages;
+
+            if (manageMessages)
+            {
+                await message.TryRemoveAllReactionsAsync(_messageCache);
+            }
+            else
+            {
+                await message.TryDeleteAsync(_messageCache);
+            }
+
             await message.ModifyOrResendAsync(embed: builder.Build(), cache: _messageCache);
 
             await _logService.LogAsync(new LogMessage(LogSeverity.Verbose, "Command", $"New: Getting info for character: {characters.Keys.ElementAt(characterIndex)} ({characters.Values.ElementAt(characterIndex)})"));
@@ -442,8 +452,18 @@ namespace Fergun.Modules
             builder.Title = Locate("CustomCharacterCreation");
             builder.Description = Locate("CustomCharacterPrompt");
 
+            bool manageMessages = message.Author is IGuildUser guildUser && guildUser.GetPermissions((IGuildChannel)message.Channel).ManageMessages;
+
+            if (manageMessages)
+            {
+                await message.TryRemoveAllReactionsAsync(_messageCache);
+            }
+            else
+            {
+                await message.TryDeleteAsync(_messageCache);
+            }
+
             await message.ModifyOrResendAsync(embed: builder.Build(), cache: _messageCache);
-            _ = message.TryRemoveAllReactionsAsync();
 
             var userInput = await NextMessageAsync(true, true, TimeSpan.FromMinutes(5));
 

--- a/src/Modules/Moderation.cs
+++ b/src/Modules/Moderation.cs
@@ -8,6 +8,7 @@ using Discord.Net;
 using Fergun.Attributes;
 using Fergun.Attributes.Preconditions;
 using Fergun.Extensions;
+using Fergun.Services;
 
 namespace Fergun.Modules
 {
@@ -17,6 +18,13 @@ namespace Fergun.Modules
     [RequireContext(ContextType.Guild, ErrorMessage = "NotSupportedInDM")]
     public class Moderation : FergunBase
     {
+        private static MessageCacheService _messageCache;
+
+        public Moderation(MessageCacheService messageCache)
+        {
+            _messageCache ??= messageCache;
+        }
+
         [RequireUserPermission(GuildPermission.BanMembers, ErrorMessage = "UserRequireBanMembers")]
         [RequireBotPermission(GuildPermission.BanMembers, ErrorMessage = "BotRequireBanMembers")]
         [Command("ban")]
@@ -61,7 +69,7 @@ namespace Fergun.Modules
                 return FergunResult.FromError(string.Format(Locate("NumberOutOfIndex"), 1, DiscordConfig.MaxMessagesPerBatch));
             }
 
-            var messages = await Context.Channel.GetMessagesAsync(Context.Message, Direction.Before, count).Flatten().ToListAsync();
+            var messages = await Context.Channel.GetMessagesAsync(_messageCache, Context.Message, Direction.Before, count).Flatten().ToListAsync();
 
             // Get the total message count before being filtered.
             int totalMessages = messages.Count;

--- a/src/Modules/Music.cs
+++ b/src/Modules/Music.cs
@@ -27,11 +27,13 @@ namespace Fergun.Modules
         private readonly MusicService _musicService;
         private static LogService _logService;
         private static GeniusApi _geniusApi;
+        private static MessageCacheService _messageCache;
 
-        public Music(MusicService musicService, LogService logService)
+        public Music(MusicService musicService, LogService logService, MessageCacheService messageCache)
         {
             _musicService = musicService;
             _logService ??= logService;
+            _messageCache ??= messageCache;
             _geniusApi ??= new GeniusApi(FergunClient.Config.GeniusApiToken);
         }
 
@@ -245,7 +247,7 @@ namespace Fergun.Modules
                 }
                 else
                 {
-                    await message.ModifyOrResendAsync(embed: builder2.Build());
+                    await message.ModifyOrResendAsync(embed: builder2.Build(), cache: _messageCache);
                 }
             }
             return FergunResult.FromSuccess();

--- a/src/Modules/Other.cs
+++ b/src/Modules/Other.cs
@@ -419,16 +419,6 @@ namespace Fergun.Modules
                 GuildUtils.UserConfigCache[Context.User.Id] = userConfig;
                 valueList = Locate(userConfig.IsOptedOutSnipe);
 
-                if (reaction.Emote.Name == "1️⃣" && userConfig.IsOptedOutSnipe)
-                {
-                    int removed = _messageCache.ClearOnPredicate(x => x.Value.Author.Id == reaction.UserId);
-                    if (removed > 0)
-                    {
-                        await _logService.LogAsync(new LogMessage(LogSeverity.Verbose, "Command",
-                            $"Privacy: Removed {removed} deleted/edited messages from the cache from user {reaction.UserId}."));
-                    }
-                }
-
                 builder.Fields[4] = new EmbedFieldBuilder { Name = Locate("Value"), Value = valueList, IsInline = true };
                 _ = message!.RemoveReactionAsync(reaction.Emote, reaction.UserId);
                 await message.ModifyAsync(x => x.Embed = builder.Build());

--- a/src/Modules/Other.cs
+++ b/src/Modules/Other.cs
@@ -439,7 +439,7 @@ namespace Fergun.Modules
             }
             else
             {
-                msg = await Context.Channel.GetMessageAsync(messageId.Value);
+                msg = await Context.Channel.GetMessageAsync(_messageCache, messageId.Value);
                 if (msg == null)
                 {
                     return FergunResult.FromError(Locate("InvalidMessageID"));

--- a/src/Modules/Utility.cs
+++ b/src/Modules/Utility.cs
@@ -343,8 +343,10 @@ namespace Fergun.Modules
         public async Task<RuntimeResult> BigEditSnipe([Summary("bigeditsnipeParam1")] IMessageChannel channel = null)
         {
             channel ??= Context.Channel;
-            var messages = _messageCache.Values
-                .Where(x => x.SourceEvent == CachedMessageSourceEvent.MessageUpdated && x.Channel.Id == channel.Id)
+            var messages = _messageCache
+                .GetCacheForChannel(channel, MessageSourceEvent.MessageUpdated)
+                .Values
+                .Where(x => x.SourceEvent == MessageSourceEvent.MessageUpdated)
                 .OrderByDescending(x => x.CachedAt)
                 .Take(20)
                 .ToArray();
@@ -380,8 +382,10 @@ namespace Fergun.Modules
         public async Task<RuntimeResult> BigSnipe([Summary("bigsnipeParam1")] IMessageChannel channel = null)
         {
             channel ??= Context.Channel;
-            var messages = _messageCache.Values
-                .Where(x => x.SourceEvent == CachedMessageSourceEvent.MessageDeleted && x.Channel.Id == channel.Id)
+            var messages = _messageCache
+                .GetCacheForChannel(channel, MessageSourceEvent.MessageDeleted)
+                .Values
+                .Where(x => x.SourceEvent == MessageSourceEvent.MessageDeleted)
                 .OrderByDescending(x => x.CachedAt)
                 .Take(20)
                 .ToArray();
@@ -780,8 +784,10 @@ namespace Fergun.Modules
         public async Task EditSnipe([Summary("snipeParam1")] IMessageChannel channel = null)
         {
             channel ??= Context.Channel;
-            var message = _messageCache.Values
-                .Where(x => x.SourceEvent == CachedMessageSourceEvent.MessageUpdated && x.Channel.Id == channel.Id)
+            var message = _messageCache
+                .GetCacheForChannel(channel, MessageSourceEvent.MessageUpdated)
+                .Values
+                .Where(x => x.SourceEvent == MessageSourceEvent.MessageUpdated)
                 .OrderByDescending(x => x.CachedAt)
                 .FirstOrDefault();
 
@@ -1504,8 +1510,10 @@ namespace Fergun.Modules
         public async Task Snipe([Summary("snipeParam1")] IMessageChannel channel = null)
         {
             channel ??= Context.Channel;
-            var message = _messageCache.Values
-                .Where(x => x.SourceEvent == CachedMessageSourceEvent.MessageDeleted && x.Channel.Id == channel.Id)
+            var message = _messageCache
+                .GetCacheForChannel(channel, MessageSourceEvent.MessageDeleted)
+                .Values
+                .Where(x => x.SourceEvent == MessageSourceEvent.MessageDeleted)
                 .OrderByDescending(x => x.CachedAt)
                 .FirstOrDefault();
 

--- a/src/Modules/Utility.cs
+++ b/src/Modules/Utility.cs
@@ -1194,7 +1194,7 @@ namespace Fergun.Modules
                     .WithDescription(Format.Url(Locate("HastebinLink"), hastebinUrl))
                     .WithColor(FergunClient.Config.EmbedColor);
 
-                await message.ModifyOrResendAsync(embed: builder.Build());
+                await message.ModifyOrResendAsync(embed: builder.Build(), cache: _messageCache);
             }
             catch (Exception e) when (e is HttpRequestException || e is TaskCanceledException)
             {

--- a/src/Modules/Utility.cs
+++ b/src/Modules/Utility.cs
@@ -876,7 +876,7 @@ namespace Fergun.Modules
         public async Task<RuntimeResult> Identify([Summary("identifyParam1")] string url = null)
         {
             UrlFindResult result;
-            (url, result) = await Context.GetLastUrlAsync(FergunClient.Config.MessagesToSearchLimit, true, url);
+            (url, result) = await Context.GetLastUrlAsync(FergunClient.Config.MessagesToSearchLimit, _messageCache, true, url);
             if (result != UrlFindResult.UrlFound)
             {
                 return FergunResult.FromError(string.Format(Locate(result.ToString()), FergunClient.Config.MessagesToSearchLimit));
@@ -1003,7 +1003,7 @@ namespace Fergun.Modules
         public async Task<RuntimeResult> Invert([Remainder, Summary("invertParam1")] string url = null)
         {
             UrlFindResult result;
-            (url, result) = await Context.GetLastUrlAsync(FergunClient.Config.MessagesToSearchLimit, true, url);
+            (url, result) = await Context.GetLastUrlAsync(FergunClient.Config.MessagesToSearchLimit, _messageCache, true, url);
             if (result != UrlFindResult.UrlFound)
             {
                 return FergunResult.FromError(string.Format(Locate(result.ToString()), FergunClient.Config.MessagesToSearchLimit));
@@ -1068,7 +1068,7 @@ namespace Fergun.Modules
             }
 
             UrlFindResult result;
-            (url, result) = await Context.GetLastUrlAsync(FergunClient.Config.MessagesToSearchLimit, true, url);
+            (url, result) = await Context.GetLastUrlAsync(FergunClient.Config.MessagesToSearchLimit, _messageCache, true, url);
             if (result != UrlFindResult.UrlFound)
             {
                 return FergunResult.FromError(string.Format(Locate(result.ToString()), FergunClient.Config.MessagesToSearchLimit));
@@ -1126,7 +1126,7 @@ namespace Fergun.Modules
             }
 
             UrlFindResult result;
-            (url, result) = await Context.GetLastUrlAsync(FergunClient.Config.MessagesToSearchLimit, true, url);
+            (url, result) = await Context.GetLastUrlAsync(FergunClient.Config.MessagesToSearchLimit, _messageCache, true, url);
             if (result != UrlFindResult.UrlFound)
             {
                 return FergunResult.FromError(string.Format(Locate(result.ToString()), FergunClient.Config.MessagesToSearchLimit));
@@ -1239,7 +1239,7 @@ namespace Fergun.Modules
             }
 
             UrlFindResult result;
-            (url, result) = await Context.GetLastUrlAsync(FergunClient.Config.MessagesToSearchLimit, true, url);
+            (url, result) = await Context.GetLastUrlAsync(FergunClient.Config.MessagesToSearchLimit, _messageCache, true, url);
             if (result != UrlFindResult.UrlFound)
             {
                 return FergunResult.FromError(string.Format(Locate(result.ToString()), FergunClient.Config.MessagesToSearchLimit));

--- a/src/Services/CommandCacheService.cs
+++ b/src/Services/CommandCacheService.cs
@@ -25,6 +25,7 @@ namespace Fergun.Services
         private readonly DiscordSocketClient _client;
         private readonly Func<SocketMessage, Task> _cmdHandler;
         private readonly double _maxMessageTime;
+        private readonly MessageCacheService _messageCache;
 
         private CommandCacheService()
         {
@@ -41,9 +42,10 @@ namespace Fergun.Services
         /// <param name="logger">An optional method to use for logging.</param>
         /// <param name="period">The interval between invocations of the cache clearing, in milliseconds.</param>
         /// <param name="maxMessageTime">The max. message longevity, in hours.</param>
+        /// <param name="messageCache">The message cache.</param>
         /// <exception cref="ArgumentOutOfRangeException">Thrown if capacity is less than 1.</exception>
         public CommandCacheService(DiscordSocketClient client, int capacity = 200, Func<SocketMessage, Task> cmdHandler = null,
-            Func<LogMessage, Task> logger = null, int period = 1800000, double maxMessageTime = 2.0)
+            Func<LogMessage, Task> logger = null, int period = 1800000, double maxMessageTime = 2.0, MessageCacheService messageCache = null)
         {
             _client = client;
 
@@ -62,6 +64,7 @@ namespace Fergun.Services
 
             _max = capacity;
             _maxMessageTime = maxMessageTime;
+            _messageCache = messageCache;
 
             // Create a timer that will clear out cached messages.
             _autoClear = new Timer(OnTimerFired, null, period, period);
@@ -233,7 +236,7 @@ namespace Fergun.Services
             {
                 if (TryGetValue(cacheable.Id, out ulong responseId))
                 {
-                    var message = await channel.GetMessageAsync(responseId);
+                    var message = await channel.GetMessageAsync(_messageCache, responseId);
                     if (message != null)
                     {
                         await _logger(new LogMessage(LogSeverity.Verbose, "CmdCache", $"Command message ({cacheable.Id}) deleted. Deleting the response..."));
@@ -259,7 +262,7 @@ namespace Fergun.Services
 
                 if (TryGetValue(cacheable.Id, out ulong responseId))
                 {
-                    var response = await channel.GetMessageAsync(responseId);
+                    var response = await channel.GetMessageAsync(_messageCache, responseId);
                     if (response == null)
                     {
                         await _logger(new LogMessage(LogSeverity.Info, "CmdCache", $"A command message ({cacheable.Id}) associated to a response was found but the response ({responseId}) was already deleted."));

--- a/src/Services/CommandHandlingService.cs
+++ b/src/Services/CommandHandlingService.cs
@@ -159,6 +159,10 @@ namespace Fergun.Services
                 await _logService.LogAsync(new LogMessage(LogSeverity.Info, "Command", $"Unknown command: \"{context.Message.Content}\", sent by {context.User} in {context.Display()}"));
                 return;
             }
+
+            // Update the last time a command was used in this guild.
+            _services.GetService<MessageCacheService>()?.UpdateLastCommandUsageTime(context.Guild.Id);
+
             var command = optionalCommand.Value;
 
             if (command.Module.Name != Constants.DevelopmentModuleName)
@@ -181,6 +185,8 @@ namespace Fergun.Services
 
             // the command was successful, we don't care about this result, unless we want to log that a command succeeded.
             if (result.IsSuccess) return;
+
+            // Update the last time anyone in the guild has used a command
 
             double ignoreTime = Constants.DefaultIgnoreTime;
             switch (result.Error)

--- a/src/Services/CommandHandlingService.cs
+++ b/src/Services/CommandHandlingService.cs
@@ -160,8 +160,11 @@ namespace Fergun.Services
                 return;
             }
 
-            // Update the last time a command was used in this guild.
-            _services.GetService<MessageCacheService>()?.UpdateLastCommandUsageTime(context.Guild.Id);
+            if (context.Guild != null)
+            {
+                // Update the last time a command was used in this guild.
+                _services.GetService<MessageCacheService>()?.UpdateLastCommandUsageTime(context.Guild.Id);
+            }
 
             var command = optionalCommand.Value;
 
@@ -364,15 +367,16 @@ namespace Fergun.Services
 
             IUserMessage response;
             bool found = cache.TryGetValue(userMessage.Id, out ulong messageId);
+            var messageCache = _services.GetService<MessageCacheService>();
 
-            if (found && (response = (IUserMessage)await userMessage.Channel.GetMessageAsync(messageId)) != null)
+            if (found && (response = (IUserMessage)await userMessage.Channel.GetMessageAsync(messageCache, messageId)) != null)
             {
                 await response.ModifyAsync(x =>
                 {
                     x.Content = text;
                     x.Embed = embed;
                 });
-                response = (IUserMessage)await userMessage.Channel.GetMessageAsync(messageId);
+                response = (IUserMessage)await userMessage.Channel.GetMessageAsync(messageCache, messageId);
             }
             else
             {

--- a/src/Services/MessageCacheService.cs
+++ b/src/Services/MessageCacheService.cs
@@ -392,6 +392,7 @@ namespace Fergun.Services
             _client.MessageReceived -= MessageReceived;
             _client.MessageDeleted -= MessageDeleted;
             _client.MessageUpdated -= MessageUpdated;
+            _client.MessagesBulkDeleted -= MessagesBulkDeleted;
             _client.LeftGuild -= LeftGuild;
 
             _disposed = true;


### PR DESCRIPTION
This PR replaces the message cache service with an optimized one, adding support to sent messages and including the edited/deleted message cache into a single service.

The optimized message cache will work *almost* like the default message cache included in Discord.Net, but it will only cache messages from servers that have used at least 1 command in the last x hours.

The edited/deleted message cache will work as before.

Limitations:
- It's not possible to directly update parts of a message, since the properties don't have public setters and the Update() method is internal. This makes it harder to update the reactions and embeds, but there are workarounds for this, like adding to a cached message private fields that represents the updated values of a property, and use them instead of the original message's properties.

- Sometimes the `MessageUpdated` event will return partial messages with specific changes from the original messages (like link previews/embeds). In this case only the embeds will be updated on the cached message.

- The `Reactions` property won't have the correct `ReactionMetadata` values because `ReactionMetadata` doesn't have a public constructor and its properties don't have public setters. 